### PR TITLE
Fix segfault when shrinking shell window

### DIFF
--- a/src/clerk_draw.c
+++ b/src/clerk_draw.c
@@ -20,7 +20,7 @@ unsigned int clrk_draw_text(int x, int y, const char *text, int fg, int bg)
   unsigned w = 0, width = tb_width();
   struct tb_cell cells[width];
 
-  while (*text != '\0') {
+  while (w < width && *text != '\0') {
     cells[w].ch = *text++;
     cells[w].fg = fg;
     cells[w].bg = bg;


### PR DESCRIPTION
Hi robem,

I fixed a problem where you overrun your stack allocated buffer which causes a segfault. I was able to trigger it by shrinking the shell window to a really small size.
