### PR TITLE
Fix todo display when adding new project

### DIFF
--- a/src/clerk.c
+++ b/src/clerk.c
@@ -153,7 +153,7 @@ clrk_project_t* clrk_project_add(const char *name)
   LOG("current lproject "PTR, clerk.current);
 
   clerk.number_of_projects++;
-  clrk_draw_project_line();
+  clrk_draw();
 
   LOG("after draw line");
 


### PR DESCRIPTION
When adding a new project the old todo list is displayed while the
project list bar already marks the new project as selected.
This change fixes this inconsistency by redrawing the todo list in
addition to the project list bar.
