### PR TITLE
Fix -j/--json config setting

### DIFF
--- a/include/clerk.h
+++ b/include/clerk.h
@@ -57,7 +57,7 @@ typedef struct clrk_clerk {
 /*
  * Initialize Clerk with default values and draws user interface.
  */
-void clrk_init(const char *config);
+void clrk_init(const char *json);
 
 /*
  * Create/add a new project

--- a/include/clerk.h
+++ b/include/clerk.h
@@ -49,7 +49,7 @@ typedef struct clrk_project {
 } clrk_project_t;
 
 typedef struct clrk_clerk {
-  char *json;
+  const char *json;
   clrk_list_t *project_list;
   clrk_list_elem_t *current;
 } clrk_clerk_t;
@@ -57,7 +57,7 @@ typedef struct clrk_clerk {
 /*
  * Initialize Clerk with default values and draws user interface.
  */
-void clrk_init(void);
+void clrk_init(const char *config);
 
 /*
  * Create/add a new project

--- a/src/clerk.c
+++ b/src/clerk.c
@@ -575,11 +575,11 @@ void clrk_todo_running(void)
   LOG("END");
 }
 
-void clrk_init(const char *config)
+void clrk_init(const char *json)
 {
   HERE();
   clerk.current               = NULL;
-  clerk.json                  = config;
+  clerk.json                  = json;
   clerk.project_list          = malloc(sizeof(clrk_list_t));
   assert(clerk.project_list);
   clerk.project_list->first   = NULL;

--- a/src/clerk.c
+++ b/src/clerk.c
@@ -575,11 +575,11 @@ void clrk_todo_running(void)
   LOG("END");
 }
 
-void clrk_init(void)
+void clrk_init(const char *config)
 {
   HERE();
   clerk.current               = NULL;
-  clerk.json                  = NULL;
+  clerk.json                  = config;
   clerk.project_list          = malloc(sizeof(clrk_list_t));
   assert(clerk.project_list);
   clerk.project_list->first   = NULL;

--- a/src/main.c
+++ b/src/main.c
@@ -16,7 +16,7 @@ int main(int argc, char *const *argv)
 
   int opt, option_index;
   const char *short_options = "hj:";
-  const char *config = NULL;
+  const char *json = NULL;
   struct option long_options[] = {
     {"help", no_argument, 0, 'h'},
     {"json", required_argument, 0, 'j'},
@@ -38,7 +38,7 @@ int main(int argc, char *const *argv)
         usage(argv[0]);
         return EXIT_SUCCESS;
       case 'j':
-        config = optarg;
+        json = optarg;
         break;
       case '?':
         return EXIT_FAILURE;
@@ -50,7 +50,7 @@ int main(int argc, char *const *argv)
 
   tb_select_output_mode(TB_OUTPUT_256);
 
-  clrk_init(config);
+  clrk_init(json);
 
   clrk_loop_normal();
 

--- a/src/main.c
+++ b/src/main.c
@@ -2,8 +2,6 @@
 #include <stdio.h>
 #include <clerk.h>
 
-extern clrk_clerk_t clerk;
-
 void usage(char *program_name)
 {
   printf("Usage: %s\n\n"
@@ -18,6 +16,7 @@ int main(int argc, char *const *argv)
 
   int opt, option_index;
   const char *short_options = "hj:";
+  const char *config = NULL;
   struct option long_options[] = {
     {"help", no_argument, 0, 'h'},
     {"json", required_argument, 0, 'j'},
@@ -39,7 +38,7 @@ int main(int argc, char *const *argv)
         usage(argv[0]);
         return EXIT_SUCCESS;
       case 'j':
-        clerk.json = optarg;
+        config = optarg;
         break;
       case '?':
         return EXIT_FAILURE;
@@ -51,7 +50,7 @@ int main(int argc, char *const *argv)
 
   tb_select_output_mode(TB_OUTPUT_256);
 
-  clrk_init();
+  clrk_init(config);
 
   clrk_loop_normal();
 


### PR DESCRIPTION
The -j/--json config option for specifying a config file did not work. The problem was that after invoking getopt_long to parse the command line options, the clerk_init() function overwrote the 'json' field of
the clrk_clerk_t object.
This change assigns the argument passed to the -j/--json option to a temporary that is passed to clerk_init() and is used to initialize the 'json' string of the global clrk_clerk_t directly.
