### PR TITLE
Fix project and todo input

### DIFF
--- a/src/clerk.c
+++ b/src/clerk.c
@@ -237,9 +237,9 @@ static void clrk_project_edit_current(void)
     project = clrk_list_elem_data(clerk.current);
 
     buffer = clrk_input(project->name);
-    if (buffer == '\0') {
+    if (buffer == NULL || buffer[0] == '\0') {
       /* No empty string permitted */
-      return;
+      goto end;
     }
 
     if (strlen(project->name) != strlen(buffer)) {
@@ -250,6 +250,7 @@ static void clrk_project_edit_current(void)
     clrk_draw_project_line();
   }
 
+end:
   free(buffer);
 }
 
@@ -384,7 +385,7 @@ static void clrk_todo_edit_current(void)
       todo = clrk_list_elem_data(project->current);
 
       buffer = clrk_input(todo->message);
-      if (buffer == '\0') {
+      if (buffer == NULL || buffer[0] == '\0') {
         /* Deleting the whole todo text is not permitted. Use 'T' instead. */
         goto end;
       }

--- a/src/clerk.c
+++ b/src/clerk.c
@@ -339,12 +339,12 @@ clrk_todo_t * clrk_todo_add(const char *text)
 {
   HERE();
   clrk_project_t *project;
-  clrk_todo_t *todo;
+  clrk_todo_t *todo = NULL;
   clrk_list_elem_t *elem;
   char *buffer = NULL;
 
   if (clerk.project_list == NULL) {
-    return NULL;
+    goto out;
   }
 
   project = clrk_list_elem_data(clerk.current);
@@ -354,6 +354,11 @@ clrk_todo_t * clrk_todo_add(const char *text)
   } else {
     buffer = malloc(strlen(text) + 1);
     strncpy(buffer, text, strlen(text) + 1);
+  }
+
+  /* Empty strings are not permitted. */
+  if (buffer == NULL || buffer[0] == '\0') {
+    goto out;
   }
 
   todo = clrk_todo_new(buffer);
@@ -367,6 +372,7 @@ clrk_todo_t * clrk_todo_add(const char *text)
   project->current = elem;
   clrk_draw_todos();
 
+out:
   LOG("END");
   return todo;
 }


### PR DESCRIPTION
Fix two issues:
o acceptance of an empty project name
o assertion failure when canceling user input when creating a new todo
