### PR TITLE
fix cursor scroll problem when editing text

### DIFF
--- a/src/clerk.c
+++ b/src/clerk.c
@@ -110,7 +110,7 @@ add_char:
           tb_set_cursor(--cx, cy);
         }
       } else if (event.key == TB_KEY_ARROW_RIGHT) {
-        if (buffer_idx < sizeof(buffer) && buffer[buffer_idx] != '\0') {
+        if (buffer_idx < buffer_size && buffer[buffer_idx] != '\0') {
           tb_set_cursor(++cx, cy);
         }
       }


### PR DESCRIPTION
When the user edits a todo or project name he can scroll through all
characters to the left until the beginning of the string is reached. However,
when scrolling back into the other direction (towards the end of the string)
scrolling stops before reaching the end.
This change fixes the problem by changing the cursor move condition to rely on
the correct buffer size.
