### PR TITLE
fix --todos command line parameter

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,7 @@ int main(int argc, char *const *argv)
   struct option long_options[] = {
     {"help", no_argument, 0, 'h'},
     {"config", required_argument, 0, 'c'},
-    {"json", required_argument, 0, 'j'},
+    {"todos", required_argument, 0, 't'},
     {0, 0, 0, 0}
   };
 


### PR DESCRIPTION
Although the help mentions a --todos command line parameter, specifying this
parameter yields an error. This change fixes the issue.
