### PR TITLE
fix todo loading error

### DIFF
--- a/src/clerk_json.c
+++ b/src/clerk_json.c
@@ -313,7 +313,7 @@ bool clrk_load(void)
   parser_handle = yajl_alloc((const yajl_callbacks*)&callbacks, NULL, &parser_context);
 
   LOG("before parse");
-  parser_status = yajl_parse(parser_handle, (const unsigned char*)buffer, sizeof(buffer));
+  parser_status = yajl_parse(parser_handle, (const unsigned char*)buffer, file_size);
 
   if (parser_status != yajl_status_ok) {
     yajl_free(parser_handle);


### PR DESCRIPTION
Since the error code return check was added to check the result of
yajl_parse we see an error being reported everytime we load a file
containing todos.
The reason is a wrong buffer size (greater than the actual size) being
passed to the yajl_parse function which would then continue reading
uninitialized memory and trying to interpret it.
This change fixes the issue.
