### PR TITLE
add support for HOME & END keys

### DIFF
--- a/src/clerk.c
+++ b/src/clerk.c
@@ -116,6 +116,12 @@ add_char:
         if (buffer_idx < buffer_size && buffer[buffer_idx] != '\0') {
           tb_set_cursor(++cx, cy);
         }
+      } else if (event.key == TB_KEY_HOME) {
+        cx = CLRK_DRAW_INPUT_START_X;
+        tb_set_cursor(cx, cy);
+      } else if (event.key == TB_KEY_END) {
+        cx = CLRK_DRAW_INPUT_START_X + text_len;
+        tb_set_cursor(cx, cy);
       }
       LOG("key %d", event.key);
     } else if (event.type == TB_EVENT_RESIZE) {


### PR DESCRIPTION
Usually (i.e., in basically all command line [and even GUI based] programs),
the HOME/POS1 key moves the cursor to the beginning of the line and the END
key can be used to move the cursor to the end of current line. Such movements
are not yet supported by clerk.
This change adds code for setting the cursor to the appropriate position when
inputting text in clerk.
