### PR TITLE
provide clrk_save handler for SIGUSR1 signal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.sconsign.dblite
+/clerk
+**.o

--- a/SConstruct
+++ b/SConstruct
@@ -19,6 +19,7 @@ env.Program('clerk',
             src/clerk_draw.c
             src/clerk_list.c
             src/clerk_json.c
+            src/clerk_sig.c
             '''.split(),
             LIBS = ['termbox', 'yajl_s'],
             parse_flags = "-Wall"

--- a/include/clerk.h
+++ b/include/clerk.h
@@ -57,12 +57,14 @@ typedef struct clrk_clerk {
   color_configuration_t *colors;
   unsigned width;
   unsigned height;
+  clrk_exit_func exit_func;
+  volatile bool exit_func_invoked;
 } clrk_clerk_t;
 
 /*
  * Initialize Clerk with default values and draws user interface.
  */
-void clrk_init(const char *json, const char *config);
+void clrk_init(const char *json, const char *config, clrk_exit_func exit_func);
 
 /*
  * Create/add a new project
@@ -101,8 +103,10 @@ void clrk_todo_info(void);
 
 /*
  * Start Clerk.
- * If this function returns then Clerk will end.
+ * If this function returns then Clerk will end. The return value indicates
+ * whether the exit function supplied during initialization lead to the exit
+ * or not.
  */
-void clrk_loop_normal(void);
+bool clrk_loop_normal(void);
 
 #endif

--- a/include/clerk.h
+++ b/include/clerk.h
@@ -12,6 +12,7 @@
 #include <clerk_list.h>
 #include <clerk_json.h>
 #include <clerk_log.h>
+#include <clerk_sig.h>
 
 #define CLRK_MIN_HEIGHT 10
 #define CLRK_MIN_WIDTH  20

--- a/include/clerk_sig.h
+++ b/include/clerk_sig.h
@@ -1,0 +1,8 @@
+#ifndef _CLRK_SIG_H
+#define _CLRK_SIG_H
+
+#include <stdbool.h>
+
+bool clrk_sig_init(void);
+
+#endif

--- a/include/clerk_sig.h
+++ b/include/clerk_sig.h
@@ -3,6 +3,8 @@
 
 #include <stdbool.h>
 
-bool clrk_sig_init(void);
+typedef void (*clrk_exit_func)(void);
+
+bool clrk_sig_init(clrk_exit_func exit_func);
 
 #endif

--- a/src/clerk.c
+++ b/src/clerk.c
@@ -2,6 +2,19 @@
 
 clrk_clerk_t clerk;
 
+static void clrk_set_status_and_await_key_press(const char *status)
+{
+  clrk_draw_status(status);
+  /* wait for ANY input key */
+  tb_present();
+  struct tb_event event;
+  while (tb_poll_event(&event)) {
+    if (event.type == TB_EVENT_KEY) {
+      break;
+    }
+  }
+}
+
 static char * clrk_input(char *text)
 {
   HERE();
@@ -650,15 +663,7 @@ void clrk_init(const char *json, const char *config)
   if (!clrk_read_config()) {
     /* Show help screen */
     clrk_draw_help();
-    clrk_draw_status("Couldn't load config");
-    /* wait for ANY input key */
-    tb_present();
-    struct tb_event event;
-    while (tb_poll_event(&event)) {
-      if (event.type == TB_EVENT_KEY) {
-        break;
-      }
-    }
+    clrk_set_status_and_await_key_press("Couldn't load config");
   }
 
   clrk_draw_init();
@@ -666,21 +671,17 @@ void clrk_init(const char *json, const char *config)
   if (!clrk_load()) {
     /* Show help screen */
     clrk_draw_help();
-    clrk_draw_status("Couldn't load todos");
-    /* wait for ANY input key */
-    tb_present();
-    struct tb_event event;
-    while (tb_poll_event(&event)) {
-      if (event.type == TB_EVENT_KEY) {
-        break;
-      }
-    }
+    clrk_set_status_and_await_key_press("Couldn't load todos");
   }
 
   if (clerk.project_list->first) {
     clerk.current = clerk.project_list->first;
     clrk_project_t *project = clrk_list_elem_data(clerk.current);
     project->current = project->todo_list->first;
+  }
+
+  if (!clrk_sig_init()) {
+    clrk_set_status_and_await_key_press("Couldn't install signal handler");
   }
 
   clrk_draw();

--- a/src/clerk_sig.c
+++ b/src/clerk_sig.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+#include <signal.h>
+#include <stddef.h>
+
+#include <clerk_log.h>
+#include <clerk_json.h>
+#include <clerk_sig.h>
+
+/* A signal that triggers a clrk_save(). */
+#define CLRK_SIGNAL_SAVE SIGUSR1
+
+typedef struct sigaction sigaction_t;
+
+static void clrk_save_handler(int sig, siginfo_t *siginfo, void *context)
+{
+  HERE();
+  assert(sig == CLRK_SIGNAL_SAVE);
+
+  clrk_save();
+  LOG("END");
+}
+
+bool clrk_sig_init(void)
+{
+  int result;
+  sigset_t mask;
+  sigaction_t sig = {};
+
+  sigemptyset(&mask);
+  /*
+   * We do not want to receive signals while handling one in order to not run
+   * into concurrency issues.
+   */
+  sigaddset(&mask, CLRK_SIGNAL_SAVE);
+
+  sig.sa_mask = mask;
+  sig.sa_flags = SA_SIGINFO;
+  sig.sa_sigaction = &clrk_save_handler;
+
+  result = sigaction(CLRK_SIGNAL_SAVE, &sig, NULL);
+  return result == 0;
+}

--- a/src/clerk_sig.c
+++ b/src/clerk_sig.c
@@ -8,8 +8,12 @@
 
 /* A signal that triggers a clrk_save(). */
 #define CLRK_SIGNAL_SAVE SIGUSR1
+#define CLRK_SIGNAL_EXIT1 SIGTERM
+#define CLRK_SIGNAL_EXIT2 SIGINT
 
 typedef struct sigaction sigaction_t;
+
+static clrk_exit_func clrk_exit;
 
 static void clrk_save_handler(int sig, siginfo_t *siginfo, void *context)
 {
@@ -20,9 +24,18 @@ static void clrk_save_handler(int sig, siginfo_t *siginfo, void *context)
   LOG("END");
 }
 
-bool clrk_sig_init(void)
+static void clrk_exit_handler(int sig, siginfo_t *siginfo, void *context)
 {
-  int result;
+  HERE();
+  assert(sig == CLRK_SIGNAL_EXIT1 || sig == CLRK_SIGNAL_EXIT2);
+  assert(clrk_exit != NULL);
+
+  (*clrk_exit)();
+  LOG("END");
+}
+
+bool clrk_setup_save_handler(void)
+{
   sigset_t mask;
   sigaction_t sig = {};
 
@@ -37,6 +50,31 @@ bool clrk_sig_init(void)
   sig.sa_flags = SA_SIGINFO;
   sig.sa_sigaction = &clrk_save_handler;
 
-  result = sigaction(CLRK_SIGNAL_SAVE, &sig, NULL);
-  return result == 0;
+  return sigaction(CLRK_SIGNAL_SAVE, &sig, NULL) == 0;
+}
+
+bool clrk_setup_exit_handler(clrk_exit_func exit_func)
+{
+  sigset_t mask;
+  sigaction_t sig = {};
+
+  assert(clrk_exit == NULL);
+
+  sigemptyset(&mask);
+  sigaddset(&mask, CLRK_SIGNAL_EXIT1);
+  sigaddset(&mask, CLRK_SIGNAL_EXIT2);
+
+  clrk_exit = exit_func;
+
+  sig.sa_mask = mask;
+  sig.sa_flags = SA_SIGINFO;
+  sig.sa_sigaction = &clrk_exit_handler;
+
+  return sigaction(CLRK_SIGNAL_EXIT1, &sig, NULL) == 0 &&
+         sigaction(CLRK_SIGNAL_EXIT2, &sig, NULL) == 0;
+}
+
+bool clrk_sig_init(clrk_exit_func exit_func)
+{
+  return clrk_setup_save_handler() && clrk_setup_exit_handler(exit_func);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -56,10 +56,14 @@ int main(int argc, char *const *argv)
 
   tb_select_output_mode(TB_OUTPUT_256);
 
-  clrk_init(todos, config);
+  clrk_init(todos, config, &tb_shutdown);
 
-  clrk_loop_normal();
-
-  tb_shutdown();
+  /*
+   * Depending on whether the loop exited by means of tb_shutdown (as supplied
+   * to clrk_init) we do not invoke here ourselves.
+   */
+  if (!clrk_loop_normal()) {
+    tb_shutdown();
+  }
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
When a clerk instance is running but the user has no access to it (e.g.,
because he/she is logged in remotely and clerk is running in a different
session), it might still be desireable to terminate this instance and
start a new one. However, until now the user had no chance to save any
changes he/she made in clerk beforehand.
This change introduces a signal handler for SIGUSR1 that can be used to
save the changes that were made previously.
